### PR TITLE
Allow RollableTable Buttons module on all systems

### DIFF
--- a/rolltable-buttons/rolltable-buttons/module.json
+++ b/rolltable-buttons/rolltable-buttons/module.json
@@ -5,7 +5,6 @@
   "version": "0.4.0",
   "author": "RaySSharma",
   "scripts": ["./scripts/RTB.js"],
-  "systems": ["dnd5e"],
   "languages": [{
       "lang": "en",
       "name": "English",


### PR DESCRIPTION
Rollable Tables are not specific to D&D 5 only and this simple change allows RollableTable Buttons to work on other systems too (verified on "Simple Worldbuilding System".

Fixes: #8